### PR TITLE
crates must be imported via extern crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub trait SyncEventHandler {
 }
 
 #[cfg(not(target_os = "android"))]
-use this_platform_is_not_supported;
+extern crate this_platform_is_not_supported;
 
 static mut G_MAINTHREAD_BOXED: Option<*mut Receiver<()>> = Option::None;
 


### PR DESCRIPTION
faced following issue while building servo.

 in Rust 2018, some crates are special and must be imported via ```extern crate``` instead of ```use```
````
error[E0432]: unresolved import `this_platform_is_not_supported`
   --> /home/zayn/.cargo/registry/src/github.com-1ecc6299db9ec823/android_injected_glue-0.2.3/src/lib.rs:162:5
```